### PR TITLE
fix(isauthorized): fix undefined values in req.session

### DIFF
--- a/src/middlewares/isAuthorized.js
+++ b/src/middlewares/isAuthorized.js
@@ -36,7 +36,7 @@ module.exports = catchAsync(async (req, res, next) => {
     throw new ApplicationError(messages.notFound('token'), StatusCodes.NOT_FOUND);
   }
 
-  req.session = { token, id: decoded.id, email: decoded.email };
+  req.session = { token, id: decoded.sub.id, email: decoded.sub.email };
 
   next();
 });


### PR DESCRIPTION
When creating the user session, the values of id and email were undefined because after decoding the
token those values were stored respectively in decoded.sub.id and decoded.sub.email and not in
decoded.id and decoded.email.