### PR TITLE
feat: added docker setup for dev, and testing environments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+
+**/.git
+**/.gitignore
+**/.vscode
+**/node_modules
+**/coverage
+
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:lts-alpine3.12
+
+RUN npm i npm@latest -g
+
+RUN mkdir /opt/node_app && chown node:node /opt/node_app
+WORKDIR /opt/node_app
+
+USER node
+
+COPY package.json package-lock.json* ./
+
+RUN npm install && npm cache clean --force
+
+ENV PATH /opt/node_app/node_modules/.bin:$PATH
+
+WORKDIR /opt/node_app/app
+
+COPY . .
+
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ $ npm test
 $ yarn test
 ```
 
+### Docker
+
+Bloodboiler comes with Docker support, you can develop and test your code using Docker for minimal configuration, Nodemon takes care of restarting the application inside Docker so you can code locally.
+
+```sh
+# Code Locally with:
+$ npm run docker:dev
+# or
+$ yarn docker:dev
+
+# Run Test Suites inside Docker:
+$ npm run docker:test
+# or
+$ yarn docker:test
+```
+
+> NOTE: In order to use the methods listed above, make sure you have Docker installed on your local machine!
+
 ## Documentation
 
 You might want to check the API docs as well!

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  backend:
+    environment:
+      - DB_HOST=database
+    command: bash -c "
+      npx sequelize db:migrate &&
+      npm run start:dev -L"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  backend:
+    environment:
+      - DB_HOST=database
+    command: ['npm', 'test']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3'
+
+services:
+  database:
+    container_name: bloodboiler-sql-database
+    image: postgres:13-alpine
+    environment:
+      - POSTGRES_DB=${DB_NAME}
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASS}
+    ports:
+      - '5432:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - app-network
+    logging:
+      driver: none
+
+  backend:
+    container_name: bloodboiler-sql-backend
+    build: ../..
+    image: bloodboiler
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/opt/node_app/app
+    networks:
+      - app-network
+    depends_on:
+      - database
+
+volumes:
+  pgdata:
+
+networks:
+  app-network:
+    driver: bridge

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "start:staging": "NODE_ENV=staging node app.js",
     "start:dev": "NODE_ENV=development nodemon app.js",
     "start:debug": "NODE_ENV=development node --inspect-brk=5858 app.js",
+    "docker:dev": "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up",
+    "docker:test": "docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit",
     "test": "jest -i",
     "test:coverage": "jest -i && codecov",
     "pretest": "NODE_ENV=test npx sequelize db:create && NODE_ENV=test npx sequelize db:migrate",
@@ -23,7 +25,7 @@
     "hooks": {
       "pre-commit": "pretty-quick --staged",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-push": "npm test"
+      "pre-push": "npm run docker:test"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Proposed changes:

Adds docker support for developing **locally** without having to setup local machine, and run tests using **docker** as well.

This is good because it allows the developer to run the **application using the same environment** it would run on `production`.

Also, `nodemon` takes care of rebooting the API container as the developer makes changes to the code. 😃 

## Closes issue(s):

N/a

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/lucas-a-pelegrino/node-bloodboiler-sequelized/blob/master/CONTRIBUTING.md) guidelines;
- [x] Lint and tests pass locally with my changes;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have added necessary documentation (if appropriate);

## Further comments

N/a